### PR TITLE
Enable Stackdriver Kubernetes Engine monitoring

### DIFF
--- a/modules/beta-private-cluster/variables.tf
+++ b/modules/beta-private-cluster/variables.tf
@@ -246,13 +246,13 @@ variable "configure_ip_masq" {
 variable "logging_service" {
   type        = string
   description = "The logging service that the cluster should write logs to. Available options include logging.googleapis.com, logging.googleapis.com/kubernetes (beta), and none"
-  default     = "logging.googleapis.com"
+  default     = "logging.googleapis.com/kubernetes"
 }
 
 variable "monitoring_service" {
   type        = string
   description = "The monitoring service that the cluster should write metrics to. Automatically send metrics from pods in the cluster to the Google Cloud Monitoring API. VM metrics will be collected by Google Compute Engine regardless of this setting Available options include monitoring.googleapis.com, monitoring.googleapis.com/kubernetes (beta) and none"
-  default     = "monitoring.googleapis.com"
+  default     = "monitoring.googleapis.com/kubernetes"
 }
 
 variable "create_service_account" {


### PR DESCRIPTION
In order to enable Stackdriver Kubernetes Engine monitoring, values of these 2 variables have to be changed.